### PR TITLE
js rules: add prefer-const

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -48,6 +48,7 @@
     "max-len": [2, 120, 2],
     "generator-star-spacing": ["error", "before"],
     "promise/avoid-new": 0,
-    "promise/always-return": 0
+    "promise/always-return": 0,
+    "prefer-const": ["error"]
   }
 }


### PR DESCRIPTION
This rule is aimed at flagging variables that are declared using let keyword, but never reassigned after the initial assignment.
Read more at:
https://eslint.org/docs/rules/prefer-const